### PR TITLE
Fix security rule for user endpoints

### DIFF
--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
                                 "/api/auth/register",
                                 "/api/auth/login",
                                 "/api/auth/refresh",
-                                "/api/user/**",
                                 "/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- restrict `/api/user/**` endpoints that should require authentication

## Testing
- `./services/auth-service/gradlew -p services/auth-service test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684213ef218083298281ae83d24d0bcc