### PR TITLE
Add buggy order pricing service

### DIFF
--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/model/OrderItem.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/model/OrderItem.java
@@ -1,0 +1,18 @@
+package com.ushirobyte.food.auth_service.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderItem {
+    private String name;
+    private double price;
+    private int quantity;
+}

--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/OrderPriceService.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/OrderPriceService.java
@@ -1,0 +1,9 @@
+package com.ushirobyte.food.auth_service.service;
+
+import com.ushirobyte.food.auth_service.model.OrderItem;
+
+import java.util.List;
+
+public interface OrderPriceService {
+    double calculateTotalPrice(List<OrderItem> items);
+}

--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/impl/OrderPriceServiceImpl.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/impl/OrderPriceServiceImpl.java
@@ -1,0 +1,23 @@
+package com.ushirobyte.food.auth_service.service.impl;
+
+import com.ushirobyte.food.auth_service.model.OrderItem;
+import com.ushirobyte.food.auth_service.service.OrderPriceService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class OrderPriceServiceImpl implements OrderPriceService {
+    @Override
+    public double calculateTotalPrice(List<OrderItem> items) {
+        if (items == null || items.isEmpty()) {
+            return 0.0;
+        }
+        double total = 0.0;
+        for (OrderItem item : items) {
+            total += item.getPrice() * item.getQuantity();
+        }
+        // BUG: total price should not be divided by number of items
+        return total / items.size();
+    }
+}


### PR DESCRIPTION
## Summary
- add `OrderItem` model
- add `OrderPriceService` interface
- implement `OrderPriceServiceImpl` with an intentional bug (dividing total price by item count)

## Testing
- `./services/auth-service/gradlew -p services/auth-service build`

------
https://chatgpt.com/codex/tasks/task_e_68498c5d5f2c832988db216797a3761e