### PR TITLE
Add random joke endpoint

### DIFF
--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/controller/FunController.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/controller/FunController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+import com.ushirobyte.food.auth_service.service.JokeService;
 
 import java.util.Map;
 
@@ -15,11 +16,17 @@ import java.util.Map;
 public class FunController {
 
     private final RestTemplate restTemplate;
+    private final JokeService jokeService;
 
     @GetMapping("/quote")
     public ResponseEntity<String> getRandomQuote() {
         Map<?, ?> response = restTemplate.getForObject("https://api.kanye.rest/", Map.class);
         String quote = response != null && response.get("quote") != null ? response.get("quote").toString() : "No quote";
         return ResponseEntity.ok(quote);
+    }
+
+    @GetMapping("/joke")
+    public ResponseEntity<String> getRandomJoke() {
+        return ResponseEntity.ok(jokeService.getRandomJoke());
     }
 }

--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/JokeService.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/JokeService.java
@@ -1,0 +1,5 @@
+package com.ushirobyte.food.auth_service.service;
+
+public interface JokeService {
+    String getRandomJoke();
+}

--- a/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/impl/JokeServiceImpl.java
+++ b/services/auth-service/src/main/java/com/ushirobyte/food/auth_service/service/impl/JokeServiceImpl.java
@@ -1,0 +1,40 @@
+package com.ushirobyte.food.auth_service.service.impl;
+
+import com.ushirobyte.food.auth_service.service.JokeService;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class JokeServiceImpl implements JokeService {
+
+    private final List<String> jokes = new ArrayList<>();
+
+    public JokeServiceImpl() throws IOException {
+        ClassPathResource resource = new ClassPathResource("jokes.txt");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.trim().isEmpty()) {
+                    jokes.add(line.trim());
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getRandomJoke() {
+        if (jokes.isEmpty()) {
+            return "No jokes available";
+        }
+        int index = ThreadLocalRandom.current().nextInt(jokes.size());
+        return jokes.get(index);
+    }
+}

--- a/services/auth-service/src/main/resources/jokes.txt
+++ b/services/auth-service/src/main/resources/jokes.txt
@@ -1,0 +1,6 @@
+Why don't eggs tell jokes? They'd crack each other up.
+I'm on a seafood diet. I see food, and I eat it.
+Why did the tomato blush? Because it saw the salad dressing.
+I asked the waiter to bring me something to eat and he brought the menu.
+Why did the scarecrow win an award? Because he was outstanding in his field!
+Did you hear about the Italian chef who died? He pasta way.


### PR DESCRIPTION
## Summary
- implement `JokeService` and `JokeServiceImpl` with jokes loaded from `jokes.txt`
- extend `FunController` with `/api/fun/joke` endpoint
- provide a small list of jokes in resources

## Testing
- `./gradlew build --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684d7dd61db4832993db31f535df6a5e